### PR TITLE
Ensure AppSession receives logger configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1165,12 +1165,45 @@ class NightscoutMentraApp extends AppServer {
 /* ---------- init ---------- */
 const server=new NightscoutMentraApp({ packageName:PACKAGE_NAME, apiKey:MENTRAOS_API_KEY, port:PORT });
 
+// El SDK moderno espera siempre un logger funcional dentro de la AppSession.
+// En Render el constructor de AppSession accedía a `config.app.logger` y
+// provocaba un TypeError cuando no existía. Generamos un logger básico y lo
+// propagamos explícitamente en la configuración para mantener compatibilidad
+// con builds antiguas.
+const fallbackLogger = (() => {
+  const base = {
+    debug: (...args) => console.debug(...args),
+    info: (...args) => console.info(...args),
+    warn: (...args) => console.warn(...args),
+    error: (...args) => console.error(...args),
+  };
+  base.child = () => base;
+  return base;
+})();
+
+const resolveLogger = () => {
+  const loggerCandidate = server?.logger;
+  if (loggerCandidate && typeof loggerCandidate === "object") {
+    if (typeof loggerCandidate.child !== "function") {
+      loggerCandidate.child = () => loggerCandidate;
+    }
+    return loggerCandidate;
+  }
+  return fallbackLogger;
+};
+
 let activeAppSession=null;
-const createAppSession=(opts={})=> new AppSession({
-  packageName:PACKAGE_NAME,
-  apiKey:MENTRAOS_API_KEY,
-  ...opts,
-});
+const createAppSession=(opts={})=> {
+  const logger = resolveLogger();
+  const appRef = server && typeof server === "object" ? server : { logger };
+  return new AppSession({
+    packageName:PACKAGE_NAME,
+    apiKey:MENTRAOS_API_KEY,
+    app: appRef,
+    logger,
+    ...opts,
+  });
+};
 
 if (AppSession && typeof AppSession === "function") {
   connectWithRetry(


### PR DESCRIPTION
## Summary
- add a resilient fallback logger and expose it when creating AppSession
- forward the app reference and logger to avoid AppSession constructor crashes when the SDK expects config.app.logger

## Testing
- not run (private @mentra/sdk dependency is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d3e366148083269cc89de1c6e636af